### PR TITLE
Update docstrings to match comment color

### DIFF
--- a/themes/default.json
+++ b/themes/default.json
@@ -350,6 +350,15 @@
       }
     },
     {
+      "name": "Docstring",
+      "scope": [
+        "string.quoted.docstring"
+      ],
+      "settings": {
+        "foreground": "#75715E"
+      }
+    },
+    {
       "name": "Template Definition",
       "scope": [
         "punctuation.definition.template-expression",


### PR DESCRIPTION
Docstrings are most often used as large comment blocks in languages like Python. Having them be the same color as normal strings adds a lot of visual noise.

This change gives docstrings the same color format as is used in comments, greatly reducing that visual noise.

Before
------
![mono_before](https://github.com/user-attachments/assets/f1348d41-2b08-410d-afe4-a142a51b3f34)

After
-----
![mono_after](https://github.com/user-attachments/assets/31d2bb87-810c-4f4e-a901-da943cb1de65)

